### PR TITLE
Fix redirect issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "homepageDemos": false,
+  "homepageDemos": true,
   "server": "",
   "basepath": ""
 }


### PR DESCRIPTION
This works for me locally. I am not sure why it worked before despite having `homepageDemos": false`. It should have always redirected to `/app`. Therefore, I am not 100% sure that this fix will work on higlass.io.